### PR TITLE
Used @Primary annotation to avoid ambiguity exceptions

### DIFF
--- a/src/main/java/com/abhi/beanexample/AppConfig.java
+++ b/src/main/java/com/abhi/beanexample/AppConfig.java
@@ -2,6 +2,7 @@ package com.abhi.beanexample;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 
 @Configuration
 public class AppConfig {
@@ -24,6 +25,15 @@ public class AppConfig {
     Payment payment2(){
         Payment p = new Payment();
         p.setProviderName("GPay");
+        return p;
+    }
+
+    // @Primary annotation used as default bean when multiple bean's was initiated with same type(Payment) to avoid ambiguity exceptions
+    @Primary
+    @Bean
+    Payment payment3(){
+        Payment p = new Payment();
+        p.setProviderName("Rapipay");
         return p;
     }
 

--- a/src/main/java/com/abhi/beanexample/BeanExampleApplication.java
+++ b/src/main/java/com/abhi/beanexample/BeanExampleApplication.java
@@ -24,6 +24,9 @@ public class BeanExampleApplication {
 		Payment payment2 = context.getBean("payment2", Payment.class);
 		System.out.println(payment2.getProviderName());
 
+		Payment payment3 = context.getBean(Payment.class);
+		System.out.println(payment3.getProviderName());
+
 		String name = context.getBean(String.class);
 		System.out.println(name);
 	}


### PR DESCRIPTION
Used @Primary annotation to avoid ambiguity exceptions when multiple beans created with same type and @Primary is used to read the default bean value.